### PR TITLE
allow SYS_clock_gettime

### DIFF
--- a/machine/src/micro_vm/syscall.rs
+++ b/machine/src/micro_vm/syscall.rs
@@ -125,6 +125,8 @@ pub fn syscall_whitelist() -> Vec<BpfRule> {
         BpfRule::new(libc::SYS_readlink),
         BpfRule::new(libc::SYS_getrandom),
         BpfRule::new(libc::SYS_fallocate),
+        #[cfg(target_env = "gnu")]
+        BpfRule::new(libc::SYS_clock_gettime),
         madvise_rule(),
     ]
 }


### PR DESCRIPTION
I maintain the stratovirt package in nixos/nixpkgs. It was not starting up for me until I added this one syscall to the allowlist.

---

Unfortunately, my account on gitee.com was immediately blocked before I could do anything:
> 抱歉，您的帐号已被系统屏蔽
> 屏蔽原因: 账号违规-AD-OVS